### PR TITLE
Give option to keep CSV files locally and skip upload to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Full list of options in `config.json`:
 | aws_secret_access_key               | String  | No         | S3 Secret Access Key. If not provided, `AWS_SECRET_ACCESS_KEY` environment variable will be used. |
 | aws_session_token                   | String  | No         | AWS Session token. If not provided, `AWS_SESSION_TOKEN` environment variable will be used. |
 | aws_profile                         | String  | No         | AWS profile name for profile based authentication. If not provided, `AWS_PROFILE` environment variable will be used. |
-| s3_bucket                           | String  | Yes        | S3 Bucket name                                                |
+| s3_bucket                           | String  | Yes        | S3 Bucket name. Setting this to `localhost` will keep the files in temp_dir and not upload to S3.  |
 | s3_key_prefix                       | String  |            | (Default: None) A static prefix before the generated S3 key names. Using prefixes you can 
 | delimiter                           | String  |            | (Default: ',') A one-character string used to separate fields. |
 | quotechar                           | String  |            | (Default: '"') A one-character string used to quote fields containing special characters, such as the delimiter or quotechar, or which contain new-line characters. |

--- a/target_s3_csv/__init__.py
+++ b/target_s3_csv/__init__.py
@@ -39,6 +39,8 @@ def persist_messages(messages, config, s3_client):
     delimiter = config.get('delimiter', ',')
     quotechar = config.get('quotechar', '"')
     flatten   = config.get('flatten', True)
+    s3_bucket = config.get('s3_bucket')
+    skip_upload = s3_bucket == 'localhost'
 
     # Use the system specific temp directory if no custom temp_dir provided
     temp_dir = os.path.expanduser(config.get('temp_dir', tempfile.gettempdir()))
@@ -134,6 +136,8 @@ def persist_messages(messages, config, s3_client):
 
     # Upload created CSV files to S3
     for filename, target_key in filenames:
+        if skip_upload:
+            break  # Skip S3 upload and keep local files
         compressed_file = None
         if config.get("compression") is None or config["compression"].lower() == "none":
             pass  # no compression
@@ -152,7 +156,7 @@ def persist_messages(messages, config, s3_client):
                 )
         s3.upload_file(compressed_file or filename,
                        s3_client,
-                       config.get('s3_bucket'),
+                       s3_bucket,
                        target_key,
                        encryption_type=config.get('encryption_type'),
                        encryption_key=config.get('encryption_key'))
@@ -181,7 +185,7 @@ def main():
         logger.error("Invalid configuration:\n   * {}".format('\n   * '.join(config_errors)))
         sys.exit(1)
 
-    s3_client = s3.create_client(config)
+    s3_client = s3.create_client(config) if config.get('s3_bucket') != 'localhost' else None
 
     input_messages = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
     state = persist_messages(input_messages, config, s3_client)


### PR DESCRIPTION
When testing pipelines on a local machine, you don't always need
to actually send the files to S3. Sometimes you just want to
verify the data was written correctly. With this change,
specifying the s3_bucket value as 'localhost' will skip the
upload to S3 and not remove the files from temp_dir.

It also skips creation of AWS session, avoiding need to have
AWS credentials for local testing.