### PR TITLE
Set a limit on file sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Full list of options in `config.json`:
 | compression                         | String  | No         | The type of compression to apply before uploading. Supported options are `none` (default) and `gzip`. For gzipped files, the file extension will automatically be changed to `.csv.gz` for all files. |
 | naming_convention                   | String  | No         | (Default: None) Custom naming convention of the s3 key. Replaces tokens `date`, `stream`, and `timestamp` with the appropriate values. <br><br>Supports "folders" in s3 keys e.g. `folder/folder2/{stream}/export_date={date}/{timestamp}.csv`. <br><br>Honors the `s3_key_prefix`,  if set, by prepending the "filename". E.g. naming_convention = `folder1/my_file.csv` and s3_key_prefix = `prefix_` results in `folder1/prefix_my_file.csv` |
 | temp_dir                            | String  |            | (Default: platform-dependent) Directory of temporary CSV files with RECORD messages. |
+| max_file_size_mb                    | Integer | No         | (Default: 1000) Limits the size of individual files. If a stream exceeds this limit, it will automatically append an incrementing numeric sequence to each file of the stream e.g. `stream-001.csv`, `stream-002.csv`  |
 
 ### To run tests:
 

--- a/target_s3_csv/s3.py
+++ b/target_s3_csv/s3.py
@@ -75,3 +75,5 @@ def upload_file(filename, s3_client, bucket, s3_key,
         .format(filename, bucket, s3_key, encryption_desc)
     )
     s3_client.upload_file(filename, bucket, s3_key, ExtraArgs=encryption_args)
+    os.remove(filename)
+

--- a/target_s3_csv/utils.py
+++ b/target_s3_csv/utils.py
@@ -7,6 +7,9 @@ import json
 import re
 import collections
 import inflection
+import gzip
+import shutil
+import os
 
 from decimal import Decimal
 from datetime import datetime
@@ -143,3 +146,30 @@ def get_target_key(message, prefix=None, timestamp=None, naming_convention=None)
         filename = key.split('/')[-1]
         key = key.replace(filename, f'{prefix}{filename}')
     return key
+
+
+def compress_file(filename, compression=None):
+    compressed_file = None
+    if compression is None or compression.lower() == "none":
+        pass  # no compression
+    else:
+        if compression == "gzip":
+            compressed_file = f"{filename}.gz"
+            with open(filename, 'rb') as f_in:
+                with gzip.open(compressed_file, 'wb') as f_out:
+                    logger.info(f"Compressing file as '{compressed_file}'")
+                    shutil.copyfileobj(f_in, f_out)
+            os.remove(filename)
+        else:
+            raise NotImplementedError(
+                "Compression type '{}' is not supported. "
+                "Expected: 'none' or 'gzip'"
+                .format(compression)
+            )
+    return compressed_file
+
+
+def add_file_count(filename, counter=0):
+    root, ext = os.path.splitext(filename)
+    return root + f'-{counter:03}' + ext
+


### PR DESCRIPTION
Added a new configuration option for max_file_size_mb.
If a file from a single stream starts getting too big, it
automatically appends a 3 digit sequence e.g. file-001.csv
then uploads it to S3.

A new file is then started if there are additional records.
Temporary files are automatically deleted after they are
uploaded to S3 to prevent large streams from consuming unnecessary
disk space.
